### PR TITLE
Add NHL teams table for 2024/2025 season with Utah

### DIFF
--- a/2ndHomeWork/nhl_teams_2024_2025.md
+++ b/2ndHomeWork/nhl_teams_2024_2025.md
@@ -1,0 +1,36 @@
+# NHL Teams 2024/2025 Season
+
+| #  | Team                  | City             | Division          |
+|----|-----------------------|------------------|-------------------|
+| 1  | Boston Bruins         | Boston           | Atlantic          |
+| 2  | Toronto Maple Leafs   | Toronto          | Atlantic          |
+| 3  | Tampa Bay Lightning   | Tampa Bay        | Atlantic          |
+| 4  | Florida Panthers      | Sunrise          | Atlantic          |
+| 5  | Montreal Canadiens    | Montreal         | Atlantic          |
+| 6  | Detroit Red Wings     | Detroit          | Atlantic          |
+| 7  | Buffalo Sabres        | Buffalo          | Atlantic          |
+| 8  | Ottawa Senators       | Ottawa           | Atlantic          |
+| 9  | New York Rangers      | New York City    | Metropolitan      |
+| 10 | New York Islanders    | New York City    | Metropolitan      |
+| 11 | New Jersey Devils     | Newark           | Metropolitan      |
+| 12 | Carolina Hurricanes   | Raleigh          | Metropolitan      |
+| 13 | Pittsburgh Penguins   | Pittsburgh       | Metropolitan      |
+| 14 | Washington Capitals   | Washington D.C.  | Metropolitan      |
+| 15 | Philadelphia Flyers   | Philadelphia     | Metropolitan      |
+| 16 | Columbus Blue Jackets | Columbus         | Metropolitan      |
+| 17 | Vegas Golden Knights  | Las Vegas        | Pacific           |
+| 18 | Edmonton Oilers       | Edmonton         | Pacific           |
+| 19 | Los Angeles Kings     | Los Angeles      | Pacific           |
+| 20 | Seattle Kraken        | Seattle          | Pacific           |
+| 21 | Calgary Flames        | Calgary          | Pacific           |
+| 22 | Vancouver Canucks     | Vancouver        | Pacific           |
+| 23 | San Jose Sharks       | San Jose         | Pacific           |
+| 24 | Anaheim Ducks         | Anaheim          | Pacific           |
+| 25 | Dallas Stars          | Dallas           | Central           |
+| 26 | Colorado Avalanche    | Denver           | Central           |
+| 27 | Winnipeg Jets         | Winnipeg         | Central           |
+| 28 | Minnesota Wild        | Saint Paul       | Central           |
+| 29 | St. Louis Blues       | St. Louis        | Central           |
+| 30 | Nashville Predators   | Nashville        | Central           |
+| 31 | Chicago Blackhawks    | Chicago          | Central           |
+| 32 | Utah Hockey Club      | Salt Lake City   | Central           |


### PR DESCRIPTION
Correct NHL table > Team UTAH replaced ARIZONA before season started